### PR TITLE
intel-ipsec-mb: update port to 0.54.3

### DIFF
--- a/intel-ipsec-mb/Makefile
+++ b/intel-ipsec-mb/Makefile
@@ -1,8 +1,7 @@
 # $FreeBSD: head/security/intel-ipsec-mb/Makefile 548475 2020-09-13 12:52:17Z vanilla $
 
 PORTNAME=       intel-ipsec-mb
-DISTVERSIONPREFIX=      v
-DISTVERSION=    0.54.1
+DISTVERSION=    0.54.3
 DISTVERSIONSUFFIX=      -dev
 CATEGORIES=     security
 
@@ -21,6 +20,7 @@ USES=           gmake compiler:c11 localbase:ldflags
 USE_GITHUB=     yes
 GH_ACCOUNT=     intel
 GH_PROJECT=     intel-ipsec-mb
+GH_TAGNAME=	76949db
 
 USE_LDCONFIG=   yes
 PLIST_FILES=    include/intel-ipsec-mb.h \
@@ -38,6 +38,6 @@ do-install:
 
 do-test:
 	cd ${WRKSRC}/test && ./ipsec_xvalid_test -v
-	cd ${WRKSRC}/test && ./ipsec_MB_testapp -v
+	cd ${WRKSRC}/test && ./ipsec_MB_testapp --auto-detect
 
 .include <bsd.port.mk>

--- a/intel-ipsec-mb/distinfo
+++ b/intel-ipsec-mb/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1600032971
-SHA256 (intel-intel-ipsec-mb-v0.54.1-dev_GH0.tar.gz) = fa4df3a906429a81e118e8b3e4d3a0150b40ab7dca9aa58c16b72871ce97bdd1
-SIZE (intel-intel-ipsec-mb-v0.54.1-dev_GH0.tar.gz) = 987719
+TIMESTAMP = 1602193462
+SHA256 (intel-intel-ipsec-mb-0.54.3-dev-76949db_GH0.tar.gz) = e58f454d4c6448d5e06f1a0fbf636415f6bdaa9da2afc20af52eca8e7d5e086b
+SIZE (intel-intel-ipsec-mb-0.54.3-dev-76949db_GH0.tar.gz) = 1016704


### PR DESCRIPTION
Fixed issue due to multiple definitions of "imb_errno".